### PR TITLE
Update UploadController.php

### DIFF
--- a/common/modules/attachment/actions/UploadController.php
+++ b/common/modules/attachment/actions/UploadController.php
@@ -147,7 +147,7 @@ class UploadController extends Controller
                     return !isset($result['files'][0]['error']) ? [
                         'state' => 'SUCCESS',
                         'url' => $result['files'][0]['url'],
-                        'title' => $result['files'][0]['title'],
+                        'title' => $result['files'][0]['name'],
                         'original' => $result['files'][0]['name'],
                         'type' => $result['files'][0]['type'],
                         'size' => $result['files'][0]['size'],


### PR DESCRIPTION
## 报错
exception 'yii\base\ErrorException' with message 'Undefined index: title' in /opt/lampp/htdocs/www/yii2cmf/common/modules/attachment/actions/UploadController.php:150
Stack trace:
#0 /opt/lampp/htdocs/www/yii2cmf/common/modules/attachment/actions/UploadAction.php(92): ::call_user_func:{/opt/lampp/htdocs/www/yii2cmf/common/modules/attachment/actions/UploadAction.php:92}()

## 粗暴解决方案

查看 *./common/modules/attachment/widgets/MultipleWidget.php* 内无 `title` 但是，有 `name` 。不知道该 `title`赋值如何决定。遂这样粗暴解决。可有更好方法。谢谢。