### PR TITLE
Update m130524_201442_init.php

### DIFF
--- a/database/migrations/m130524_201442_init.php
+++ b/database/migrations/m130524_201442_init.php
@@ -17,7 +17,7 @@ class m130524_201442_init extends Migration
             'description' => Schema::TYPE_TEXT . " NULL",
             'created_at' => Schema::TYPE_INTEGER . "(10) NOT NULL",
             'user_id' => Schema::TYPE_INTEGER . "(10) NOT NULL DEFAULT '0'",
-            'ip' => Schema::TYPE_INTEGER . "(10) NOT NULL DEFAULT '0'",
+            'ip' => Schema::TYPE_STRING . "(20) NOT NULL DEFAULT '0'",
         ], $this->tableOptions);
 
 // article


### PR DESCRIPTION
系统迁徙到生产环节测试是发现，由于IP格式是负数，mysql默认开启了STRICT_TRANS_TABLES，导致无法存入，改大int的位数后，存的是2147483647。改成varchar就行了