### PR TITLE
[PHP 8.3] Fix `get_parent_class()` deprecation

### DIFF
--- a/common/modules/gii/generators/model/Generator.php
+++ b/common/modules/gii/generators/model/Generator.php
@@ -111,7 +111,7 @@ class Generator extends \yii\gii\generators\model\Generator
     }
     public function formView()
     {
-        $class = new ReflectionClass(get_parent_class());
+        $class = new ReflectionClass(get_parent_class($this));
 
         return dirname($class->getFileName()) . '/form.php';
     }


### PR DESCRIPTION
In PHP 8.3, [calling `get_class()` and `get_parent_class()` functions without arguments is deprecated](https://php.watch/versions/8.3/get_class-get_parent_class-parameterless-deprecated).

This fixes one instance with an identical alternative that does not cause the deprecation notice.

References:
 - [PHP RFC: Deprecate functions with overloaded signatures](https://wiki.php.net/rfc/deprecate_functions_with_overloaded_signatures)
 - [PHP 8.3: get_class() and get_parent_class() function calls without arguments deprecated](https://php.watch/versions/8.3/get_class-get_parent_class-parameterless-deprecated)